### PR TITLE
Replace template literal with console.logging two values

### DIFF
--- a/joinList.js
+++ b/joinList.js
@@ -15,4 +15,5 @@
 // Test / Driver Code below...
 const conceptList = ["gists", "types", "operators", "iteration", "problem solving"];
 const concepts = joinList(conceptList);
-console.log(`Today I learned about ${concepts}.`);
+
+console.log('Today I learned about', concepts);


### PR DESCRIPTION
* A template literal calls `.toString` on any variable inside `${}` and this can give a false positive if the student returns an array
* Changing the console.log to accept two arguments makes the output much clearer

### Output comparison between console.log and template literal

```
# template literal
Today I learned about gists,types,operators,iteration,problem solving

# console.log
Today I learned about [ 'gists', 'types', 'operators', 'iteration', 'problem solving' ]
```

